### PR TITLE
Merge beta into master for 2020.07.27.01

### DIFF
--- a/WME-HN-NavPoints.js
+++ b/WME-HN-NavPoints.js
@@ -3,7 +3,7 @@
 // @name            WME HN NavPoints (beta)
 // @namespace       https://greasyfork.org/users/166843
 // @description     Shows navigation points of all house numbers in WME
-// @version         2020.07.18.01
+// @version         2020.07.17.01
 // @author          dBsooner
 // @grant           none
 // @require         https://greasyfork.org/scripts/24851-wazewrap/code/WazeWrap.js

--- a/WME-HN-NavPoints.js
+++ b/WME-HN-NavPoints.js
@@ -3,7 +3,7 @@
 // @name            WME HN NavPoints (beta)
 // @namespace       https://greasyfork.org/users/166843
 // @description     Shows navigation points of all house numbers in WME
-// @version         2020.07.17.01
+// @version         2020.07.27.01
 // @author          dBsooner
 // @grant           none
 // @require         https://greasyfork.org/scripts/24851-wazewrap/code/WazeWrap.js


### PR DESCRIPTION
## 2020.07.27.01
<b>NEW:</b> Setting to disable house number mouseover tooltip.
<b>NEW:</b> With the mouseover tooltip disabled, script reverts to previous style of numbers to increase performance.
<b>NEW:</b> Setting to disable keeping the house numbers layer on top of other layers.
<b>CHANGE:</b> Changes to allow for better ability to select features behind house numbers: house numbers smaller, nav point line layer zindex.
<b>BUGFIX:</b> Incorrect display, omitting of data in a right-to-left text locale.
<b>BUGFIX:</b> Memory management by removing lines and numbers no longer in the map extent.